### PR TITLE
Transfo/matrix tile

### DIFF
--- a/lib/ast/matrix_trm.ml
+++ b/lib/ast/matrix_trm.ml
@@ -101,7 +101,7 @@ let access_inv (t : trm) : (trm * trms * trms) option=
 let get ?(typ: typ option) (base : trm) (dims : trms) (indices : trms) : trm =
   trm_get ?typ (access ?elem_typ:typ base dims indices)
 
-(** [get_inv t]: gets the trm inside a get oepration on an access. *)
+(** [get_inv t]: gets the trm inside a get operation on an access. *)
 let get_inv (t : trm) : (trm * trms * trms) option =
   match t.desc with
   | Trm_apps (_f,[base], _, _) when is_get_operation t -> access_inv base

--- a/lib/ast/matrix_trm.ml
+++ b/lib/ast/matrix_trm.ml
@@ -188,7 +188,7 @@ let free_inv (t : trm) : trm option = trm_delete_inv t
       dims, indices) and returns a transformed triple (base', dims', indices').
     - [x] : the variable representing the array.
     - [t] : term to inspect and transform.
-    - [indepth] (optional): if [true] (defaul, the function is applied
+    - [indepth] (optional): if [true] (default), the function is applied
       recursively to all subterms of [t]. Returns a new term where all accesses
       to [x] have been replaced using [f]. *)
 let rec access_map ?(indepth = true)
@@ -200,7 +200,7 @@ let rec access_map ?(indepth = true)
           let base', dims', indices' = f (base, dims, indices) in
           access base' dims' indices'
       | _ -> trm_map (access_map f x) t)
-  | _ when indepth == true -> trm_map (access_map f x) t
+  | _ when indepth = true -> trm_map (access_map f x) t
   | _ -> t
 
 let ghost_mindex_unfold matrix dims res_pattern =

--- a/lib/ast/matrix_trm.ml
+++ b/lib/ast/matrix_trm.ml
@@ -166,8 +166,42 @@ let alloc_inv (t : trm) : (typ * trms * bool) option =
     | Some (ty, dims) -> Some (ty, dims, true)
     | None -> None
 
+(**[let_alloc_inv] : returns :
+   - var corresponding to an array and its type
+   - all arguments used in fonction [alloc] *)
+let let_alloc_inv (t : trm) : (var * trm * trm * trms * bool) option =
+  match trm_let_inv t with
+  | Some (array_var, typ_array, alloc_trm) -> (
+      match alloc_inv alloc_trm with
+      | Some (typ_alloc, trms, init) ->
+          Some (array_var, typ_array, typ_alloc, trms, init)
+      | None -> None)
+  | None -> None
+
+    (* TODO : Combination var_def alloc_inv : let_alloc_inv *)
 let free (t : trm) : trm = trm_delete t
 let free_inv (t : trm) : trm option = trm_delete_inv t
+
+(** [access_map ?indepth f x t] applies a transformation function [f] to all
+    trms that represent an access to the array [x] within the term [t].
+    - [f] : a function applied to each array access. It takes a triple (base,
+      dims, indices) and returns a transformed triple (base', dims', indices').
+    - [x] : the variable representing the array.
+    - [t] : term to inspect and transform.
+    - [indepth] (optional): if [true] (defaul, the function is applied
+      recursively to all subterms of [t]. Returns a new term where all accesses
+      to [x] have been replaced using [f]. *)
+let rec access_map ?(indepth = true)
+    (f : typ * trms * trms -> typ * trms * trms) (x : var) (t : trm) : trm =
+  match access_inv t with
+  | Some (base, dims, indices) -> (
+      match trm_var_inv base with
+      | Some y when var_eq y x ->
+          let base', dims', indices' = f (base, dims, indices) in
+          access base' dims' indices'
+      | _ -> trm_map (access_map f x) t)
+  | _ when indepth == true -> trm_map (access_map f x) t
+  | _ -> t
 
 let ghost_mindex_unfold matrix dims res_pattern =
   ghost_call (toplevel_var (sprintf "mindex%d_unfold" (List.length dims))) (("H", res_pattern) :: ("matrix", matrix) :: List.mapi (fun i dim -> sprintf "n%d" (i+1), dim) dims)

--- a/tests/matrix/tile/tile.cpp
+++ b/tests/matrix/tile/tile.cpp
@@ -1,0 +1,65 @@
+#include <optitrust.h>
+// Testing mallocs
+int main() {
+  float * const a = MALLOC1(float, 10);
+  float * const b = MALLOC2(float, 10, 10);
+  float * const c = MALLOC3(float, 10, 10, 10);
+  // float * const d = MALLOC4(float, 10, 10, 10, 10);
+
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX1(10, i)] = i + 1;
+    b[MINDEX2(10, 10, 5, i)] = i + 1;
+    c[MINDEX3(10, 10, 10, 5, 5, i)] = i + 1;
+    // d[MINDEX4(10, 10, 10, 10, 5, 5, 5, i)] = i + 1;
+  }
+}
+// Testing callocs
+int main2() {
+  float * const a = CALLOC1(float, 10);
+  float * const b = CALLOC2(float, 10, 10);
+  float * const c = CALLOC3(float, 10, 10, 10);
+  // float * const d = CALLOC4(float, 10, 10, 10, 10);
+
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX1(10, i)] = i + 1;
+    b[MINDEX2(10, 10, 5, i)] = i + 1;
+    c[MINDEX3(10, 10, 10, 5, 5, i)] = i + 1;
+    // d[MINDEX4(10, 10, 10, 10, 5, 5, 5, i)] = i + 1;
+  }
+}
+
+// Read and Write
+int main3() {
+  float * const a = MALLOC2(float, 10, 10);
+  float * const b = MALLOC2(float, 10, 10);
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX2(10, 10, 2, i)] = i + 1;
+    b[MINDEX2(10, 10, 2, i)] = a[MINDEX2(10, 10, 2, i)];
+  }
+}
+
+// Block size and nb blocks as trms
+int main4() {
+  int N1 = 10;
+  int const block_size = 5;
+  int const nb_blocks = 2;
+  float * const a = MALLOC1(float, N1);
+
+  a[MINDEX1(N1, 4)] = 42;
+}
+
+// Unknown nb_blocks
+int main5() {
+  int N1 = 10;
+  int const block_size = 5;
+  float * const a = MALLOC1(float, N1);
+
+  a[MINDEX1(N1, 4)] = 42;
+}
+int test() {
+
+  float * const a = CALLOC1(float, 10);
+  a[MINDEX1(10,2)] = 10;
+  return 1;
+
+}

--- a/tests/matrix/tile/tile.cpp
+++ b/tests/matrix/tile/tile.cpp
@@ -4,13 +4,11 @@ int main() {
   float * const a = MALLOC1(float, 10);
   float * const b = MALLOC2(float, 10, 10);
   float * const c = MALLOC3(float, 10, 10, 10);
-  // float * const d = MALLOC4(float, 10, 10, 10, 10);
 
   for (int i = 0; i < 10; i++) {
     a[MINDEX1(10, i)] = i + 1;
     b[MINDEX2(10, 10, 5, i)] = i + 1;
     c[MINDEX3(10, 10, 10, 5, 5, i)] = i + 1;
-    // d[MINDEX4(10, 10, 10, 10, 5, 5, 5, i)] = i + 1;
   }
 }
 // Testing callocs
@@ -18,13 +16,11 @@ int main2() {
   float * const a = CALLOC1(float, 10);
   float * const b = CALLOC2(float, 10, 10);
   float * const c = CALLOC3(float, 10, 10, 10);
-  // float * const d = CALLOC4(float, 10, 10, 10, 10);
 
   for (int i = 0; i < 10; i++) {
     a[MINDEX1(10, i)] = i + 1;
     b[MINDEX2(10, 10, 5, i)] = i + 1;
     c[MINDEX3(10, 10, 10, 5, 5, i)] = i + 1;
-    // d[MINDEX4(10, 10, 10, 10, 5, 5, 5, i)] = i + 1;
   }
 }
 

--- a/tests/matrix/tile/tile.ml
+++ b/tests/matrix/tile/tile.ml
@@ -1,137 +1,25 @@
 open Optitrust
-open Ast
-open Trm
 open Target
 open Prelude
 
-(** [apply_tiling block_size nb_blocks x index_dim t]: changes all the
-    occurences of the array to the tiled form. [block_size] - size of the blocks
-    used for tiling [nb_blocks] - number of blocks used for tilling [x] - var
-    representing the array for which we want to modify the accesses [index_dim]
-    \- index of the tiled array's dimension [t] - ast node located in the same
-    level or deeper as the array declaration
-
-    assumptions:
-    - x is not used in function definitions, but only in var declarations
-    - the array_size is block_size * nb_blocks *)
-let rec apply_tiling (block_size : trm) (nb_blocks : trm) (x : typvar)
-    (index_dim : int) (t : trm) : trm =
-  let aux = apply_tiling block_size nb_blocks x index_dim in
-  match Matrix_trm.access_inv t with
-  | Some (base, dims, indices) -> (
-      match trm_var_inv base with
-      | Some y ->
-          if var_eq y x then
-            let dimfront, current_dim, dimback =
-              List.get_item_and_its_relatives index_dim dims
-            in
-            let ifront, current_index, iback =
-              List.get_item_and_its_relatives index_dim indices
-            in
-            Matrix_trm.access (trm_var x)
-              (dimfront @ [ nb_blocks; block_size ] @ dimback)
-              (ifront
-              @ [
-                  trm_trunc_div_int current_index block_size;
-                  trm_trunc_mod_int current_index block_size;
-                ]
-              @ iback)
-          else trm_map aux t
-      | _ -> trm_map aux t)
-  | _ -> trm_map aux t
-
-(** [tile_at block_name block_size index t]: transform an array declaration from
-    a normal shape into a tiled one, then call apply_tiling to change all the
-    array occurrences into the correct form. [nb_blocks] - optional, use to
-    indicate the nb of tiled blocks [block_size] - the size of the tile,
-
-    [index] - the index of the instruction inside the sequence, [t] - ast of the
-    outer sequence containing the array declaration.
-
-    Ex: t[i] -> t[i/B][i%B] *)
-let tile_at ?(nb_blocks : trm option) ~(block_size : trm) ~(index_dim : int)
-    (index : int) (t : trm) : trm =
-  let tl, result = trm_inv trm_seq_inv t in
-  let lfront, d, lback = Mlist.get_item_and_its_relatives index tl in
-  let array_var, typ, alloc_trm =
-    trm_inv ~error:"Matrix_basic.tile_at : Expected an array declaration"
-      trm_let_inv d
-  in
-  (* Comment faire si on a pas de const ? Doit-on gérer le cas ?  *)
-  let typ_alloc, trms, init =
-    trm_inv ~error:"Matrix_basic.tile_at : Expected an array declaration"
-      Matrix_trm.alloc_inv alloc_trm
-  in
-  if List.length trms <= index_dim then
-    trm_fail t
-      "Matrix_basic.tile_at: index_dim is greater than the number of dimensions"
-  else
-    let dimfront, current_dim, dimback =
-      List.get_item_and_its_relatives index_dim trms
-    in
-
-    let lfront, nb_blocks =
-      match nb_blocks with
-      | Some x -> (lfront, x)
-      | None ->
-          let new_block_var = name_to_var (array_var.name ^ "_blocks") in
-          let new_block =
-            trm_let (new_block_var, typ_int)
-              (trm_trunc_div_int
-                 (trm_add_int current_dim (trm_sub_int block_size (trm_int 1)))
-                 block_size)
-          in
-          (Mlist.push_back new_block lfront, trm_var new_block_var)
-    in
-    let new_dims = dimfront @ [ nb_blocks; block_size ] @ dimback in
-    let new_d =
-      trm_let (array_var, typ)
-        (Matrix_trm.alloc ~zero_init:init typ_alloc new_dims)
-    in
-    let lback =
-      Mlist.map
-        (fun t -> (apply_tiling block_size nb_blocks array_var index_dim) t)
-        lback
-    in
-    let new_tl = Mlist.push_back new_d lfront in
-    let new_tl = Mlist.merge new_tl lback in
-
-    trm_seq ?result new_tl
-
-(** [tile ~block_type block_size tg]: expects the target [tg] to point at an
-    array declaration. Then it takes that declaration and transforms it into a
-    tiled array. All the accesses of the targeted array are handled as well.
-    [block_size] - size of the block of tiles. [index_dim] - Index of the
-    dimension to tile [nb_blocks] - optional, numbers of blocks in the tiled
-    array Note : If nb_blocks is not given, and that the array size N is not
-    divsible by block
-
-    _size, then nb_blocks is computed as the upper part of N / block_size, this
-    will extend the array and that might incorrect if this array is used in
-    other functions Example : float * a = malloc(MSIZE1(10)) -> float * a =
-    malloc(MSIZE2(10/2,2)) *)
-let tile ?(nb_blocks : trm option) ~(block_size : trm) ~(index_dim : int)
-    (tg : target) : unit =
-  apply_at_target_paths_in_seq (tile_at ~block_size ?nb_blocks ~index_dim) tg
-
 let _ =
   Run.script_cpp (fun _ ->
-      !!tile ~block_size:(trm_int 2) ~index_dim:0
+      !!Matrix.tile ~block_size:(trm_int 2) ~index_dim:0
         [ cFunDef "test"; cVarDef "a" ];
-      !!tile ~block_size:(trm_int 2) ~index_dim:0
+      !!Matrix.tile ~block_size:(trm_int 2) ~index_dim:0
         [ cFunDef "main"; cVarDefs [ "a"; "b" ] ];
-      !!tile ~block_size:(trm_int 2) ~index_dim:2
+      !!Matrix.tile ~block_size:(trm_int 2) ~index_dim:2
         [ cFunDef "main"; cVarDef "c" ];
-      !!tile ~block_size:(trm_int 2) ~index_dim:0
+      !!Matrix.tile ~block_size:(trm_int 2) ~index_dim:0
         [ cFunDef "main2"; cVarDefs [ "a"; "b"; "c" ] ];
-      !!tile ~block_size:(trm_int 2) ~index_dim:0
+      !!Matrix.tile ~block_size:(trm_int 2) ~index_dim:0
         [ cFunDef "main3"; cVarDef "a" ];
       let block_size, _ = find_var "block_size" [ cFunDef "main4" ] in
-      !!tile ~block_size:(trm_var block_size)
+      !!Matrix.tile ~block_size:(trm_var block_size)
         ~nb_blocks:(trm_find_var "nb_blocks" [ cFunDef "main4" ])
         ~index_dim:0
         [ cFunDef "main4"; cVarDef "a" ];
-      !!tile
+      !!Matrix.tile
         ~block_size:(trm_find_var "block_size" [ cFunDef "main5" ])
         ~index_dim:0
         [ cFunDef "main5"; cVarDef "a" ])

--- a/tests/matrix/tile/tile.ml
+++ b/tests/matrix/tile/tile.ml
@@ -1,0 +1,137 @@
+open Optitrust
+open Ast
+open Trm
+open Target
+open Prelude
+
+(** [apply_tiling block_size nb_blocks x index_dim t]: changes all the
+    occurences of the array to the tiled form. [block_size] - size of the blocks
+    used for tiling [nb_blocks] - number of blocks used for tilling [x] - var
+    representing the array for which we want to modify the accesses [index_dim]
+    \- index of the tiled array's dimension [t] - ast node located in the same
+    level or deeper as the array declaration
+
+    assumptions:
+    - x is not used in function definitions, but only in var declarations
+    - the array_size is block_size * nb_blocks *)
+let rec apply_tiling (block_size : trm) (nb_blocks : trm) (x : typvar)
+    (index_dim : int) (t : trm) : trm =
+  let aux = apply_tiling block_size nb_blocks x index_dim in
+  match Matrix_trm.access_inv t with
+  | Some (base, dims, indices) -> (
+      match trm_var_inv base with
+      | Some y ->
+          if var_eq y x then
+            let dimfront, current_dim, dimback =
+              List.get_item_and_its_relatives index_dim dims
+            in
+            let ifront, current_index, iback =
+              List.get_item_and_its_relatives index_dim indices
+            in
+            Matrix_trm.access (trm_var x)
+              (dimfront @ [ nb_blocks; block_size ] @ dimback)
+              (ifront
+              @ [
+                  trm_trunc_div_int current_index block_size;
+                  trm_trunc_mod_int current_index block_size;
+                ]
+              @ iback)
+          else trm_map aux t
+      | _ -> trm_map aux t)
+  | _ -> trm_map aux t
+
+(** [tile_at block_name block_size index t]: transform an array declaration from
+    a normal shape into a tiled one, then call apply_tiling to change all the
+    array occurrences into the correct form. [nb_blocks] - optional, use to
+    indicate the nb of tiled blocks [block_size] - the size of the tile,
+
+    [index] - the index of the instruction inside the sequence, [t] - ast of the
+    outer sequence containing the array declaration.
+
+    Ex: t[i] -> t[i/B][i%B] *)
+let tile_at ?(nb_blocks : trm option) ~(block_size : trm) ~(index_dim : int)
+    (index : int) (t : trm) : trm =
+  let tl, result = trm_inv trm_seq_inv t in
+  let lfront, d, lback = Mlist.get_item_and_its_relatives index tl in
+  let array_var, typ, alloc_trm =
+    trm_inv ~error:"Matrix_basic.tile_at : Expected an array declaration"
+      trm_let_inv d
+  in
+  (* Comment faire si on a pas de const ? Doit-on gérer le cas ?  *)
+  let typ_alloc, trms, init =
+    trm_inv ~error:"Matrix_basic.tile_at : Expected an array declaration"
+      Matrix_trm.alloc_inv alloc_trm
+  in
+  if List.length trms <= index_dim then
+    trm_fail t
+      "Matrix_basic.tile_at: index_dim is greater than the number of dimensions"
+  else
+    let dimfront, current_dim, dimback =
+      List.get_item_and_its_relatives index_dim trms
+    in
+
+    let lfront, nb_blocks =
+      match nb_blocks with
+      | Some x -> (lfront, x)
+      | None ->
+          let new_block_var = name_to_var (array_var.name ^ "_blocks") in
+          let new_block =
+            trm_let (new_block_var, typ_int)
+              (trm_trunc_div_int
+                 (trm_add_int current_dim (trm_sub_int block_size (trm_int 1)))
+                 block_size)
+          in
+          (Mlist.push_back new_block lfront, trm_var new_block_var)
+    in
+    let new_dims = dimfront @ [ nb_blocks; block_size ] @ dimback in
+    let new_d =
+      trm_let (array_var, typ)
+        (Matrix_trm.alloc ~zero_init:init typ_alloc new_dims)
+    in
+    let lback =
+      Mlist.map
+        (fun t -> (apply_tiling block_size nb_blocks array_var index_dim) t)
+        lback
+    in
+    let new_tl = Mlist.push_back new_d lfront in
+    let new_tl = Mlist.merge new_tl lback in
+
+    trm_seq ?result new_tl
+
+(** [tile ~block_type block_size tg]: expects the target [tg] to point at an
+    array declaration. Then it takes that declaration and transforms it into a
+    tiled array. All the accesses of the targeted array are handled as well.
+    [block_size] - size of the block of tiles. [index_dim] - Index of the
+    dimension to tile [nb_blocks] - optional, numbers of blocks in the tiled
+    array Note : If nb_blocks is not given, and that the array size N is not
+    divsible by block
+
+    _size, then nb_blocks is computed as the upper part of N / block_size, this
+    will extend the array and that might incorrect if this array is used in
+    other functions Example : float * a = malloc(MSIZE1(10)) -> float * a =
+    malloc(MSIZE2(10/2,2)) *)
+let tile ?(nb_blocks : trm option) ~(block_size : trm) ~(index_dim : int)
+    (tg : target) : unit =
+  apply_at_target_paths_in_seq (tile_at ~block_size ?nb_blocks ~index_dim) tg
+
+let _ =
+  Run.script_cpp (fun _ ->
+      !!tile ~block_size:(trm_int 2) ~index_dim:0
+        [ cFunDef "test"; cVarDef "a" ];
+      !!tile ~block_size:(trm_int 2) ~index_dim:0
+        [ cFunDef "main"; cVarDefs [ "a"; "b" ] ];
+      !!tile ~block_size:(trm_int 2) ~index_dim:2
+        [ cFunDef "main"; cVarDef "c" ];
+      !!tile ~block_size:(trm_int 2) ~index_dim:0
+        [ cFunDef "main2"; cVarDefs [ "a"; "b"; "c" ] ];
+      !!tile ~block_size:(trm_int 2) ~index_dim:0
+        [ cFunDef "main3"; cVarDef "a" ];
+      let block_size, _ = find_var "block_size" [ cFunDef "main4" ] in
+      !!tile ~block_size:(trm_var block_size)
+        ~nb_blocks:(trm_find_var "nb_blocks" [ cFunDef "main4" ])
+        ~index_dim:0
+        [ cFunDef "main4"; cVarDef "a" ];
+      !!tile
+        ~block_size:(trm_find_var "block_size" [ cFunDef "main5" ])
+        ~index_dim:0
+        [ cFunDef "main5"; cVarDef "a" ])

--- a/tests/matrix/tile/tile_doc.cpp
+++ b/tests/matrix/tile/tile_doc.cpp
@@ -1,0 +1,7 @@
+#include <optitrust.h>
+int main() {
+  float *a = MALLOC1(float, 10);
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX1(10,i)] = i +1;
+  }
+}

--- a/tests/matrix/tile/tile_doc.cpp
+++ b/tests/matrix/tile/tile_doc.cpp
@@ -1,7 +1,7 @@
 #include <optitrust.h>
-int main() {
-  float *a = MALLOC1(float, 10);
-  for (int i = 0; i < 10; i++) {
-    a[MINDEX1(10,i)] = i +1;
-  }
+int f(int N1, int N2, int N3, int i1, int i2, int i3) {
+  int const block_size = 10;
+  float * const a = MALLOC3(float, N1, N2, N3);
+  a[MINDEX3(N1, N2, N3, i1, i2, i3)] = 0;
 }
+// Partir avec 3 dim, pas de chiffres, mettre des variables

--- a/tests/matrix/tile/tile_doc.ml
+++ b/tests/matrix/tile/tile_doc.ml
@@ -1,0 +1,10 @@
+open Optitrust
+open Target
+open Prelude
+
+let _ =
+  Run.script_cpp (fun _ ->
+      !!Matrix.tile
+        ~block_size:(trm_find_var "block_size" [])
+        ~index_dim:1
+        [ cVarDef "a" ])

--- a/tests/matrix/tile/tile_doc_exp.cpp
+++ b/tests/matrix/tile/tile_doc_exp.cpp
@@ -1,0 +1,10 @@
+#include <optitrust.h>
+
+int f(int N1, int N2, int N3, int i1, int i2, int i3) {
+  const int block_size = 10;
+  const int a_blocks = (N2 + (block_size - 1)) / block_size;
+  float* const a =
+      (float*)malloc(MSIZE4(N1, a_blocks, block_size, N3) * sizeof(float));
+  a[MINDEX4(N1, a_blocks, block_size, N3, i1, i2 / block_size, i2 % block_size,
+            i3)] = 0;
+}

--- a/tests/matrix/tile/tile_exp.cpp
+++ b/tests/matrix/tile/tile_exp.cpp
@@ -1,0 +1,63 @@
+#include <optitrust.h>
+
+int main() {
+  const int a_blocks = (10 + (2 - 1)) / 2;
+  float* const a = (float*)malloc(MSIZE2(a_blocks, 2) * sizeof(float));
+  const int b_blocks = (10 + (2 - 1)) / 2;
+  float* const b = (float*)malloc(MSIZE3(b_blocks, 2, 10) * sizeof(float));
+  const int c_blocks = (10 + (2 - 1)) / 2;
+  float* const c = (float*)malloc(MSIZE4(10, 10, c_blocks, 2) * sizeof(float));
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX2(a_blocks, 2, i / 2, i % 2)] = i + 1;
+    b[MINDEX3(b_blocks, 2, 10, 5 / 2, 5 % 2, i)] = i + 1;
+    c[MINDEX4(10, 10, c_blocks, 2, 5, 5, i / 2, i % 2)] = i + 1;
+  }
+}
+
+int main2() {
+  const int a_blocks = (10 + (2 - 1)) / 2;
+  float* const a = (float*)calloc(MSIZE2(a_blocks, 2), sizeof(float));
+  const int b_blocks = (10 + (2 - 1)) / 2;
+  float* const b = (float*)calloc(MSIZE3(b_blocks, 2, 10), sizeof(float));
+  const int c_blocks = (10 + (2 - 1)) / 2;
+  float* const c = (float*)calloc(MSIZE4(c_blocks, 2, 10, 10), sizeof(float));
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX2(a_blocks, 2, i / 2, i % 2)] = i + 1;
+    b[MINDEX3(b_blocks, 2, 10, 5 / 2, 5 % 2, i)] = i + 1;
+    c[MINDEX4(c_blocks, 2, 10, 10, 5 / 2, 5 % 2, 5, i)] = i + 1;
+  }
+}
+
+int main3() {
+  const int a_blocks = (10 + (2 - 1)) / 2;
+  float* const a = (float*)malloc(MSIZE3(a_blocks, 2, 10) * sizeof(float));
+  float* const b = (float*)malloc(MSIZE2(10, 10) * sizeof(float));
+  for (int i = 0; i < 10; i++) {
+    a[MINDEX3(a_blocks, 2, 10, 2 / 2, 2 % 2, i)] = i + 1;
+    b[MINDEX2(10, 10, 2, i)] = a[MINDEX3(a_blocks, 2, 10, 2 / 2, 2 % 2, i)];
+  }
+}
+
+int main4() {
+  int N1 = 10;
+  const int block_size = 5;
+  const int nb_blocks = 2;
+  float* const a =
+      (float*)malloc(MSIZE2(nb_blocks, block_size) * sizeof(float));
+  a[MINDEX2(nb_blocks, block_size, 4 / block_size, 4 % block_size)] = 42;
+}
+
+int main5() {
+  int N1 = 10;
+  const int block_size = 5;
+  const int a_blocks = (N1 + (block_size - 1)) / block_size;
+  float* const a = (float*)malloc(MSIZE2(a_blocks, block_size) * sizeof(float));
+  a[MINDEX2(a_blocks, block_size, 4 / block_size, 4 % block_size)] = 42;
+}
+
+int test() {
+  const int a_blocks = (10 + (2 - 1)) / 2;
+  float* const a = (float*)calloc(MSIZE2(a_blocks, 2), sizeof(float));
+  a[MINDEX2(a_blocks, 2, 2 / 2, 2 % 2)] = 10;
+  return 1;
+}

--- a/tools/tester/.gitignore
+++ b/tools/tester/.gitignore
@@ -1,1 +1,2 @@
 batch/batch.ml
+batch/*

--- a/tools/tester/.gitignore
+++ b/tools/tester/.gitignore
@@ -1,2 +1,3 @@
 batch/batch.ml
-batch/*
+batch/batch.exe
+batch/batch.bc


### PR DESCRIPTION
Added new transformation matrix tile :    
[tile ~block_type block_size tg]: expects the target [tg] to point at an array declaration which has to be a const pointer. Then it takes that declaration and transforms it into a tiled array. All the accesses of the targeted array are handled as well.
    - [block_size] size of the block of tiles.
    - [index_dim] Index of the dimension to tile
    - [nb_blocks] optional, numbers of blocks in the tiled array Note : If
      nb_blocks is not given, and that the array size N is not divsible by
      block_size, then nb_blocks is computed as the upper part of N /
      block_size, this will extend the array and that might incorrect if this
      array is used in other functions
    Example: float * a = malloc(MSIZE1(N1))
    Into: float * a = malloc(MSIZE2(N1/block_size,block_size))   
Added new inverser : 
- let_alloc_inv : takes a vardef trm and returns the array variable and the malloc arguments 
